### PR TITLE
Fix PollenFS.sh & Make PollenFS.sh JSON more readable

### DIFF
--- a/PollenFS.sh
+++ b/PollenFS.sh
@@ -20,7 +20,27 @@ echo "May Ultrablue Rest in Peace, o7"
 sleep 1
 
 mkdir -p /etc/opt/chrome/policies/managed
-echo '{"URLBlocklist": [], "SystemFeaturesDisableList": [], "EditBookmarksEnabled": true, "ChromeOsMultiProfileUserBehavior": "unrestricted", "DeveloperToolsAvailability": 1, "DefaultPopupsSetting": 1, "AllowDeletingBrowserHistory": true, "AllowDinosaurEasterEgg": true, "IncognitoModeAvailability": 0, "AllowScreenLock": true, "ExtensionAllowedTypes": null, "ExtensionInstallAllowlist": null, "ExtensionInstallBlocklist": null, "ExtensionInstallForcelist": null, "ExtensionSettings": null, "LacrosAvailability": "user_choice", "WallpaperImage": null}' > /tmp/overlay/etc/opt/chrome/policies/managed/policy.json
+printf '
+{
+    "URLBlocklist": [], 
+    "SystemFeaturesDisableList": [], 
+    "EditBookmarksEnabled": true, 
+    "ChromeOsMultiProfileUserBehavior": "unrestricted", 
+    "DeveloperToolsAvailability": 1, 
+    "DefaultPopupsSetting": 1, 
+    "AllowDeletingBrowserHistory": true, 
+    "AllowDinosaurEasterEgg": true, 
+    "IncognitoModeAvailability": 0, 
+    "AllowScreenLock": true, 
+    "ExtensionAllowedTypes": null, 
+    "ExtensionInstallAllowlist": null, 
+    "ExtensionInstallBlocklist": null, 
+    "ExtensionInstallForcelist": null, 
+    "ExtensionSettings": null, 
+    "LacrosAvailability": "user_choice", 
+    "WallpaperImage": null
+}
+' > /etc/opt/chrome/policies/managed/pollen.json
 
 echo ""
 echo "PollenFS has been successfully applied!"


### PR DESCRIPTION
Change output directory for PollenFS.sh, it is set to /tmp/overlay/etc/ instead of /etc/

Make JSON more readable by using `printf` instead of `echo`.